### PR TITLE
* Setting upload api connections to run on the main run loop if the …

### DIFF
--- a/Cloudinary/CLUploader.m
+++ b/Cloudinary/CLUploader.m
@@ -322,6 +322,11 @@
             [runloop addPort:_port forMode:NSDefaultRunLoopMode];
             [connection scheduleInRunLoop:runloop forMode:NSDefaultRunLoopMode];
         }
+        else
+        {
+            [connection scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                                  forMode:NSDefaultRunLoopMode];
+        }
         [connection start];
     }
 }


### PR DESCRIPTION
…runLoop option is not specified or is NO

This fixes issues where NSURLConnections opened by the CLUploader would not reliably fire their associated delegate methods, even if the CLUploader was present on the main thread. As a result, the CLUploaderDelegate Protocol methods would not fire, nor would completion/error blocks.

Signed-off-by: John Gabelmann <jack.gabelmann@reticentmedia.com>