### PR TITLE
Background session support

### DIFF
--- a/Cloudinary/CLUploader.h
+++ b/Cloudinary/CLUploader.h
@@ -36,6 +36,7 @@ typedef void(^CLUploaderProgress)(NSInteger bytesWritten, NSInteger totalBytesWr
 
 
 - (void)upload:(id)file options:(NSDictionary*)options;
+- (void)uploadInBackground:(id)file options:(NSDictionary *)options;
 - (void)unsignedUpload:(id)file uploadPreset:(NSString*)uploadPreset options:(NSDictionary *)options;
 - (void)destroy:(NSString*)publicId options:(NSDictionary*)options;
 - (void)rename:(NSString*)fromPublicId toPublicId:(NSString*)toPublicId options:(NSDictionary*)options;

--- a/Cloudinary/CLUploader.m
+++ b/Cloudinary/CLUploader.m
@@ -320,12 +320,12 @@
             [self connection:dummyConnection didReceiveData:data];
             [self connectionDidFinishLoading:dummyConnection];
         }
-    } else if ([[_cloudinary get:@"background_upload" options:options defaultValue:@"NO"] boolValue]) {
+    } else if ([[_cloudinary get:@"background_upload" options:options defaultValue:@NO] boolValue]) {
         
         NSString *appID = [[NSBundle mainBundle] bundleIdentifier];
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:appID];
         NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:[NSOperationQueue mainQueue]];
-        
+
         NSURLSessionUploadTask *task = [session uploadTaskWithRequest:req fromData:nil];
         [task resume];
     }
@@ -698,17 +698,24 @@
    didSendBodyData:(int64_t)bytesSent
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+    
     [self connection:nil didSendBodyData:bytesSent totalBytesWritten:totalBytesSent totalBytesExpectedToWrite:totalBytesExpectedToSend];
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+    
     if (error) {
         [self connection:nil didFailWithError:error];
     }
+    
+    [session finishTasksAndInvalidate];
 }
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data{
-
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+    
     response = (NSHTTPURLResponse *) dataTask.response;
     _responseData = [NSMutableData dataWithData:data];
     [self connectionDidFinishLoading:nil];

--- a/Cloudinary/CLUploader.m
+++ b/Cloudinary/CLUploader.m
@@ -708,8 +708,8 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend{
 }
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data{
-    NSLog(@"%s", __PRETTY_FUNCTION__);
-    NSLog(@"%@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+
+    response = (NSHTTPURLResponse *) dataTask.response;
     _responseData = [NSMutableData dataWithData:data];
     [self connectionDidFinishLoading:nil];
 }

--- a/Cloudinary/CLUploader.m
+++ b/Cloudinary/CLUploader.m
@@ -326,7 +326,7 @@
             [self connectionDidFinishLoading:dummyConnection];
         }
     } else if ([[_cloudinary get:@"background_upload" options:options defaultValue:@NO] boolValue]) {
-        [[[self backgroundNSURLSession] dataTaskWithRequest:req] resume];
+        [[[self backgroundNSURLSession] uploadTaskWithStreamedRequest:req] resume];
     }
     else {
         connection = [[NSURLConnection alloc] initWithRequest:req delegate:self startImmediately:NO];


### PR DESCRIPTION
This pull request contains support for background URL Session loading for the CLUploader

One additional method has been added to the CLUploader interface. 
- (void)uploadInBackground:(id)file options:(NSDictionary *)options;

Using this alternative method creates an NSURLSession with background configuration. All existing CLUploader delegate callbacks will continue to be dispatched when using this method. 
