### PR TITLE
Fix CLDCrypto warning – directory not found

### DIFF
--- a/Cloudinary.podspec
+++ b/Cloudinary.podspec
@@ -31,16 +31,7 @@ Pod::Spec.new do |s|
   s.exclude_files = "Cloudinary/Frameworks/Alamofire/**/*"
   s.preserve_paths = "Cloudinary/Frameworks/CLDCrypto"
   s.xcconfig ={
-    "SWIFT_INCLUDE_PATHS"         => "$(PODS_ROOT)/Cloudinary/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME) #{File.dirname(__FILE__)}/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)",
-    "FRAMEWORK_SEARCH_PATHS"      => "$(PODS_ROOT)/Cloudinary/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME) #{File.dirname(__FILE__)}/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)"
+    "SWIFT_INCLUDE_PATHS"         => "$(PODS_ROOT)/Cloudinary/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)",
+    "FRAMEWORK_SEARCH_PATHS"      => "$(PODS_ROOT)/Cloudinary/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)"
   }
-#  s.xcconfig = {
-#    "SWIFT_INCLUDE_PATHS"         => "#{File.dirname(__FILE__)}/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)",
-#    "FRAMEWORK_SEARCH_PATHS"      => "#{File.dirname(__FILE__)}/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)"
-#  }
-#  s.xcconfig = {
-#    "SWIFT_INCLUDE_PATHS"         => "${PODS_ROOT}/Cloudinary/Frameworks/$(PLATFORM_NAME)",
-#    "FRAMEWORK_SEARCH_PATHS"      => "${PODS_ROOT}/Cloudinary/Frameworks/$(PLATFORM_NAME)"
-#  }
-
 end


### PR DESCRIPTION
This pull request fixes the following warning:

```
ld: warning: directory not found for option '-FCloudinary/Frameworks/CLDCrypto/iphonesimulator'
```

Explaining my changes: 
```ruby
"#{File.dirname(__FILE__)}/Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)"
``` 
The path above was added to both `SWIFT_INCLUDE_PATHS` and  `FRAMEWORK_SEARCH_PATHS`, although that results in `./Cloudinary/Frameworks/CLDCrypto/$(PLATFORM_NAME)`, which is not a valid path. Removing the path from both configs fixes the warning.