### PR TITLE
Broaden CLDUploadRequestParams initializer input type

### DIFF
--- a/Cloudinary/Classes/Core/Features/Uploader/RequestParams/CLDUploadRequestParams.swift
+++ b/Cloudinary/Classes/Core/Features/Uploader/RequestParams/CLDUploadRequestParams.swift
@@ -48,7 +48,7 @@ import Foundation
      
      - returns:             A new instance of CLDUploadRequestParams.
      */
-    public init(params: [String : AnyObject]) {
+    public init(params: [String : Any]) {
         super.init()
         self.params = params
     }


### PR DESCRIPTION
This prevents downcasting being necessary when passing in `params` through the initializer, since `CLDRequestParams.params` is `[String: Any]` anyway.