### PR TITLE
Fix space encoding in a generated URL

### DIFF
--- a/Cloudinary/Classes/Core/Features/Url/CLDUrl.swift
+++ b/Cloudinary/Classes/Core/Features/Url/CLDUrl.swift
@@ -386,7 +386,7 @@ import Foundation
             }
         }
         
-        let url = [prefix, resourceTypeAndType, signature, transformationStr, version , sourceName].joined(separator: "/")
+        let url = [prefix, resourceTypeAndType, signature, transformationStr, version , sourceName].joined(separator: "/").replacingOccurrences(of: " ", with: "%20")
         
         let regex = try! NSRegularExpression(pattern: "([^:])\\/+", options: NSRegularExpression.Options.caseInsensitive)
         

--- a/Example/Tests/GenerateUrlTests/UrlTests.m
+++ b/Example/Tests/GenerateUrlTests/UrlTests.m
@@ -651,4 +651,81 @@ NSString* prefix = @"https://res.cloudinary.com/test123";
     XCTAssertEqualObjects(actualResult, expectedResult, "Setting the configuration for signatureAlgorithm to sha256 and longUrlSignature = true and call for signUrl = false, should not encrypt nor add the ApiSecret to the url");
 }
 
+// MARK: - named spaces removal
+- (void)test_replaceSpaces_named_shouldCreateExpectedUrl {
+    
+    // Given
+    NSString* inputWidth    = @"100";
+    NSString* inputHeight   = @"200";
+    NSString* inputNamed    = @"named";
+    NSString* inputPublicId = @"publicId";
+    BOOL      inputSignUrl  = false;
+    
+    NSString* expectedResult = @"https://res.cloudinary.com/test123/image/upload/h_200,t_named,w_100/publicId";
+    
+    // When
+    CLDTransformation* transformation = [[[[[CLDTransformation alloc] init] setWidth:inputWidth] setNamed:inputNamed] setHeight:inputHeight];
+    NSString* actualResult            = [[[self.sut createUrl] setTransformation:transformation] generate:inputPublicId signUrl:inputSignUrl];
+    
+    // Then
+    XCTAssertEqualObjects(actualResult ,expectedResult, @"creating url with named in transformation should return the expected result");
+}
+- (void)test_replaceSpaces_namedWithSpaces_shouldReplaceSpaces {
+    
+    // Given
+    NSString* inputWidth       = @"100";
+    NSString* inputHeight      = @"200";
+    NSString* inputSpacedNamed = @"named with spaces";
+    NSString* inputPublicId    = @"publicId";
+    BOOL      inputSignUrl     = false;
+    
+    NSString* expectedResult = @"https://res.cloudinary.com/test123/image/upload/h_200,t_named%20with%20spaces,w_100/publicId";
+    
+    // When
+    CLDTransformation* transformation = [[[[[CLDTransformation alloc] init] setWidth:inputWidth] setNamed:inputSpacedNamed] setHeight:inputHeight];
+    NSString* actualResult            = [[[self.sut createUrl] setTransformation:transformation] generate:inputPublicId signUrl:inputSignUrl];
+    
+    // Then
+    XCTAssertEqualObjects(actualResult ,expectedResult, @"creating url with named in transformation should return the expected result");
+    
+}
+- (void)test_replaceSpaces_namedArray_shouldCreateExpectedUrl {
+    
+    // Given
+    NSString* inputWidth    = @"100";
+    NSString* inputHeight   = @"200";
+    NSString* inputNamed1   = @"named1";
+    NSString* inputNamed2   = @"named2";
+    NSString* inputPublicId = @"publicId";
+    BOOL      inputSignUrl  = false;
+    
+    NSString* expectedResult = @"https://res.cloudinary.com/test123/image/upload/h_200,t_named1.named2,w_100/publicId";
+    
+    // When
+    CLDTransformation* transformation = [[[[[CLDTransformation alloc] init] setWidth:inputWidth] setNamedWithArray:@[inputNamed1,inputNamed2]] setHeight:inputHeight];
+    NSString* actualResult            = [[[self.sut createUrl] setTransformation:transformation] generate:inputPublicId signUrl:inputSignUrl];
+    
+    // Then
+    XCTAssertEqualObjects(actualResult ,expectedResult, @"creating url with named in transformation should return the expected result");
+}
+- (void)test_replaceSpaces_namedArrayWithSpaces_shouldReplaceSpaces {
+    
+    // Given
+    NSString* inputWidth        = @"100";
+    NSString* inputHeight       = @"200";
+    NSString* inputSpacedNamed1 = @"named with spaces 1";
+    NSString* inputSpacedNamed2 = @"named with spaces 2";
+    NSString* inputPublicId     = @"publicId";
+    BOOL      inputSignUrl      = false;
+    
+    NSString* expectedResult = @"https://res.cloudinary.com/test123/image/upload/h_200,t_named%20with%20spaces%201.named%20with%20spaces%202,w_100/publicId";
+    
+    // When
+    CLDTransformation* transformation = [[[[[CLDTransformation alloc] init] setWidth:inputWidth] setNamedWithArray:@[inputSpacedNamed1,inputSpacedNamed2]] setHeight:inputHeight];
+    NSString* actualResult            = [[[self.sut createUrl] setTransformation:transformation] generate:inputPublicId signUrl:inputSignUrl];
+    
+    // Then
+    XCTAssertEqualObjects(actualResult ,expectedResult, @"creating url with named in transformation should return the expected result");
+}
+
 @end

--- a/Example/Tests/GenerateUrlTests/UrlTests.swift
+++ b/Example/Tests/GenerateUrlTests/UrlTests.swift
@@ -1082,6 +1082,66 @@ class UrlTests: XCTestCase {
     func testOffset(){
         XCTAssertEqual(CLDTransformation().setStartOffset("auto").asString(), "so_auto")
     }
+    
+    // MARK: - named spaces removal
+    func test_replaceSpaces_named_shouldCreateExpectedUrl() {
+        
+        // Given
+        let input = "name"
+        
+        let expectedResult = "https://res.cloudinary.com/test123/image/upload/h_101,t_name,w_100/test"
+        
+        // When
+        let transformation = CLDTransformation().setWidth(100).setHeight(101).setNamed(input)
+        let actualResult   = sut?.createUrl().setTransformation(transformation).generate("test")
+        
+        // Then
+        XCTAssertEqual(actualResult, expectedResult, "creating url with named in transformation should return the expected result")
+    }
+    func test_replaceSpaces_namedWithSpaces_shouldReplaceSpaces() {
+        
+        // Given
+        let input = "name with spaces"
+        
+        let expectedResult = "https://res.cloudinary.com/test123/image/upload/h_101,t_name%20with%20spaces,w_100/test"
+        
+        // When
+        let transformation = CLDTransformation().setWidth(100).setHeight(101).setNamed(input)
+        let actualResult   = sut?.createUrl().setTransformation(transformation).generate("test")
+        
+        // Then
+        XCTAssertEqual(actualResult, expectedResult, "creating url with named in transformation should return the expected result")
+    }
+    func test_replaceSpaces_namedArray_shouldCreateExpectedUrl() {
+        
+        // Given
+        let input1 = "name1"
+        let input2 = "name2"
+        
+        let expectedResult = "https://res.cloudinary.com/test123/image/upload/h_101,t_name1.name2,w_100/test"
+        
+        // When
+        let transformation = CLDTransformation().setWidth(100).setHeight(101).setNamed([input1, input2])
+        let actualResult   = sut?.createUrl().setTransformation(transformation).generate("test")
+        
+        // Then
+        XCTAssertEqual(actualResult, expectedResult, "creating url with named in transformation should return the expected result")
+    }
+    func test_replaceSpaces_namedArrayWithSpaces_shouldReplaceSpaces() {
+        
+        // Given
+        let input1 = "named with spaces 1"
+        let input2 = "named with spaces 2"
+        
+        let expectedResult = "https://res.cloudinary.com/test123/image/upload/h_101,t_named%20with%20spaces%201.named%20with%20spaces%202,w_100/test"
+        
+        // When
+        let transformation = CLDTransformation().setWidth(100).setHeight(101).setNamed([input1, input2])
+        let actualResult   = sut?.createUrl().setTransformation(transformation).generate("test")
+        
+        // Then
+        XCTAssertEqual(actualResult, expectedResult, "creating url with named in transformation should return the expected result")
+    }
 }
 
 


### PR DESCRIPTION
encode the any spaces in a generated URL into “%20” (underline)