### PR TITLE
Added a network error code for fetchImage()

### DIFF
--- a/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
+++ b/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
@@ -374,7 +374,8 @@ extension CLDNSessionDelegate: URLSessionTaskDelegate {
             error = request.delegate.error
         }
 
-        if let networkErrorCode = (task.response as? HTTPURLResponse)?.cld_code,
+        if let taskResponse = task.response as? HTTPURLResponse,
+            let networkErrorCode = taskResponse.cld_code, taskResponse.allHeaderFields["X-Cld-Error"] == nil,
             (networkErrorCode.isClientError || networkErrorCode.isServerError) {
             error = CLDError.error(domain: error?._domain, code: error?._code ?? networkErrorCode.rawValue, userInfo: ["statusCode": networkErrorCode])
         }

--- a/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
+++ b/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
@@ -373,9 +373,10 @@ extension CLDNSessionDelegate: URLSessionTaskDelegate {
         if request.delegate.error != nil {
             error = request.delegate.error
         }
-
+        
         if let taskResponse = task.response as? HTTPURLResponse,
-            let networkErrorCode = taskResponse.cld_code, taskResponse.allHeaderFields["X-Cld-Error"] == nil,
+            let networkErrorCode = taskResponse.cld_code,
+            (taskResponse.allHeaderFields["X-Cld-Error"] == nil && taskResponse.allHeaderFields["x-cld-error"] == nil),
             (networkErrorCode.isClientError || networkErrorCode.isServerError) {
             error = CLDError.error(domain: error?._domain, code: error?._code ?? networkErrorCode.rawValue, userInfo: ["statusCode": networkErrorCode])
         }

--- a/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
+++ b/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
@@ -373,12 +373,12 @@ extension CLDNSessionDelegate: URLSessionTaskDelegate {
         if request.delegate.error != nil {
             error = request.delegate.error
         }
-        
-        if let extendedError = error,
-            let networkErrorCode = (task.response as? HTTPURLResponse)?.cld_code {
-            error = CLDError.error(domain: extendedError._domain, code: extendedError._code, userInfo: ["statusCode": networkErrorCode.rawValue])
+
+        if let networkErrorCode = (task.response as? HTTPURLResponse)?.cld_code,
+            (networkErrorCode.isClientError || networkErrorCode.isServerError) {
+            error = CLDError.error(domain: error?._domain, code: error?._code ?? networkErrorCode.rawValue, userInfo: ["statusCode": networkErrorCode])
         }
-        
+    
         /// If an error occurred and the retrier is set, asynchronously ask the retrier if the request
         /// should be retried. Otherwise, complete the task by notifying the task delegate.
         if let retrier = retrier, let error = error {

--- a/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
+++ b/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionDelegate.swift
@@ -373,7 +373,12 @@ extension CLDNSessionDelegate: URLSessionTaskDelegate {
         if request.delegate.error != nil {
             error = request.delegate.error
         }
-
+        
+        if let extendedError = error,
+            let networkErrorCode = (task.response as? HTTPURLResponse)?.cld_code {
+            error = CLDError.error(domain: extendedError._domain, code: extendedError._code, userInfo: ["statusCode": networkErrorCode.rawValue])
+        }
+        
         /// If an error occurred and the retrier is set, asynchronously ask the retrier if the request
         /// should be retried. Otherwise, complete the task by notifying the task delegate.
         if let retrier = retrier, let error = error {

--- a/Cloudinary/Classes/Core/Network/NetworkRequest/CLDNetworkDownloadRequest.swift
+++ b/Cloudinary/Classes/Core/Network/NetworkRequest/CLDNetworkDownloadRequest.swift
@@ -53,11 +53,9 @@ internal class CLDNetworkDownloadRequest: CLDNetworkDataRequestImpl<CLDNDataRequ
     internal func responseData(_ completionHandler: ((_ responseData: Data?, _ error: NSError?) -> ())?) -> CLDNetworkDataRequest {
         
         request.responseData { response in
-            let statusCode = response.response?.statusCode
-            
             if let downloadedData = response.result.value {
                 
-                if let statusCode = statusCode,
+                if let statusCode = response.response?.statusCode,
                    !self.isAcceptableCode(code: statusCode) {
                     
                     let statusCodeError = CLDError.error(code: .unacceptableStatusCode, message: "request error - unacceptable statusCode - \(statusCode)")
@@ -68,11 +66,7 @@ internal class CLDNetworkDownloadRequest: CLDNetworkDataRequestImpl<CLDNDataRequ
                 }
             }
             else if let err = response.result.error {
-                var error = err as NSError
-                if let statusCode = statusCode {
-                    let userInfo = error.userInfo.merging(["statusCode": statusCode]) { (current, _) in current }
-                    error = CLDError.error(domain: error.domain, code: error.code, userInfo: userInfo)
-                }
+                let error = err as NSError
                 completionHandler?(nil, error)
             }
             else {

--- a/Cloudinary/Classes/Core/Utils/CLDError.swift
+++ b/Cloudinary/Classes/Core/Utils/CLDError.swift
@@ -47,12 +47,16 @@ internal struct CLDError {
         return error(domain: domain, code: code.rawValue, userInfo: userInfo)
     }
     
-    static func error(domain: String = CLDError.domain, code: Int, userInfo: [AnyHashable: Any]?) -> NSError {
+    static func error(domain: String? = CLDError.domain, code: Int, userInfo: [AnyHashable: Any]?) -> NSError {
         var info = [String: Any]()
+        var _domain = CLDError.domain
+        if let domain = domain {
+            _domain = domain
+        }
         if let userInfo = userInfo {
             userInfo.forEach {key, value in info[String(describing: key)] = value}
         }
         
-        return NSError(domain: domain, code: code, userInfo: info)
+        return NSError(domain: _domain, code: code, userInfo: info)
     }
 }

--- a/Example/Tests/BaseNetwork/Core/AuthenticationTests.swift
+++ b/Example/Tests/BaseNetwork/Core/AuthenticationTests.swift
@@ -169,8 +169,8 @@ class HTTPDigestAuthenticationTestCase: AuthenticationTestCase {
         XCTAssertNotNil(response?.request)
         XCTAssertNotNil(response?.response)
         XCTAssertEqual(response?.response?.statusCode, 401)
+        XCTAssertEqual(response?.error?._code, 401)
         XCTAssertNotNil(response?.data)
-        XCTAssertNil(response?.error)
     }
 
     func testHTTPDigestAuthenticationWithValidCredentials() {

--- a/Example/Tests/BaseNetwork/Core/AuthenticationTests.swift
+++ b/Example/Tests/BaseNetwork/Core/AuthenticationTests.swift
@@ -80,8 +80,8 @@ class BasicAuthenticationTestCase: AuthenticationTestCase {
         XCTAssertNotNil(response?.request)
         XCTAssertNotNil(response?.response)
         XCTAssertEqual(response?.response?.statusCode, 401)
+        XCTAssertEqual(response?.error?._code, 401)
         XCTAssertNotNil(response?.data)
-        XCTAssertNil(response?.error)
     }
 
     func testHTTPBasicAuthenticationWithValidCredentials() {

--- a/Example/Tests/NetworkTests/DownloaderTests.swift
+++ b/Example/Tests/NetworkTests/DownloaderTests.swift
@@ -29,6 +29,39 @@ import Cloudinary
 class DownloaderTests: NetworkBaseTest {
         
     // MARK: - Tests
+    func test_downloadImage_shouldReturnNetworkErrorCode() {
+        let expectation = self.expectation(description: "Should get 404 error")
+        var error: NSError?
+        
+        cloudinarySecured.createDownloader().fetchImage("https://www.httpstat.us/404").responseImage({ (responseImage, errorRes) in
+            error = errorRes
+            expectation.fulfill()
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        XCTAssertNotNil(error, "should get an error")
+        XCTAssertTrue(error?._code == 404, "Mock error should be 404 in this test")
+        let httpStatusCode = HTTPStatusCode(rawValue: error!._code)
+        XCTAssertNotNil(httpStatusCode, "should get a case")
+        XCTAssertTrue(httpStatusCode?.rawValue == 404)
+    }
+    
+    func test_downloadImage_withProgress_shouldReturnNetworkErrorCode() {
+        let expectation = self.expectation(description: "Should get 404 error")
+        var error: NSError?
+        cloudinarySecured.createDownloader().fetchImage("https://www.httpstat.us/404", nil, completionHandler: { _, errorRes in
+            error = errorRes
+            expectation.fulfill()
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        XCTAssertNotNil(error, "should get an error")
+        XCTAssertTrue(error?._code == 404, "Mock error should be 404 in this test")
+        let httpStatusCode = HTTPStatusCode(rawValue: error!._code)
+        XCTAssertNotNil(httpStatusCode, "should get a case")
+        XCTAssertTrue(httpStatusCode?.rawValue == 404)
+    }
+    
     func test_downloadImage_shouldDownloadImage() {
         XCTAssertNotNil(cloudinarySecured.config.apiSecret, "Must set api secret for this test")
         


### PR DESCRIPTION
### Brief Summary of Changes
I have Added a network error code as a dictionary value in NSError userInfo when calling fetchImage()

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [  ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
