### PR TITLE
Add support for `originalFilename` upload parameter

### DIFF
--- a/Cloudinary/Classes/Core/Features/Helpers/Results/Helpers/CommonResultKeys.swift
+++ b/Cloudinary/Classes/Core/Features/Helpers/Results/Helpers/CommonResultKeys.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 internal enum CommonResultKeys: CustomStringConvertible {
-    case publicId, format, version, resourceType, urlType, createdAt, length, width, height, x, y, url, secureUrl, exif, metadata, faces, colors, tags, moderation, context, phash, info, accessControl, eager, qualityAnalysis, coordinates, accessibilityAnalysis, filenameOverride
+    case publicId, format, version, resourceType, urlType, createdAt, length, width, height, x, y, url, secureUrl, exif, metadata, faces, colors, tags, moderation, context, phash, info, accessControl, eager, qualityAnalysis, coordinates, accessibilityAnalysis, originalFilename
     
     var description: String {
         switch self {
@@ -56,7 +56,7 @@ internal enum CommonResultKeys: CustomStringConvertible {
         case .qualityAnalysis:       return "quality_analysis"
         case .accessibilityAnalysis: return "accessibility_analysis"
         case .coordinates:           return "coordinates"
-        case .filenameOverride:      return "original_filename"
+        case .originalFilename:      return "original_filename"
         }
     }
 }

--- a/Cloudinary/Classes/Core/Features/Helpers/Results/Helpers/CommonResultKeys.swift
+++ b/Cloudinary/Classes/Core/Features/Helpers/Results/Helpers/CommonResultKeys.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 internal enum CommonResultKeys: CustomStringConvertible {
-    case publicId, format, version, resourceType, urlType, createdAt, length, width, height, x, y, url, secureUrl, exif, metadata, faces, colors, tags, moderation, context, phash, info, accessControl, eager, qualityAnalysis, coordinates, accessibilityAnalysis
+    case publicId, format, version, resourceType, urlType, createdAt, length, width, height, x, y, url, secureUrl, exif, metadata, faces, colors, tags, moderation, context, phash, info, accessControl, eager, qualityAnalysis, coordinates, accessibilityAnalysis, filenameOverride
     
     var description: String {
         switch self {
@@ -56,6 +56,7 @@ internal enum CommonResultKeys: CustomStringConvertible {
         case .qualityAnalysis:       return "quality_analysis"
         case .accessibilityAnalysis: return "accessibility_analysis"
         case .coordinates:           return "coordinates"
+        case .filenameOverride:      return "original_filename"
         }
     }
 }

--- a/Cloudinary/Classes/Core/Features/Uploader/RequestParams/CLDUploadRequestParams.swift
+++ b/Cloudinary/Classes/Core/Features/Uploader/RequestParams/CLDUploadRequestParams.swift
@@ -223,6 +223,10 @@ import Foundation
         return getParam(.BackgroundRemoval) as? String
     }
     
+    open var filenameOverride: String? {
+        return getParam(.FilenameOverride) as? String
+    }
+    
     fileprivate func getParam(_ param: UploadRequestParams) -> AnyObject? {
         return params[param.rawValue] as AnyObject
     }
@@ -304,6 +308,19 @@ import Foundation
     @discardableResult
     open func setBackgroundRemoval(_ backgroundRemoval: String) -> Self {
         setParam(UploadRequestParams.BackgroundRemoval.rawValue, value: backgroundRemoval)
+        return self
+    }
+    
+    /**
+     Setting this params will override the original asset name.
+     
+     - parameter filenameOverride: New file name
+     
+     - returns:                    The same instance of CLDUploadRequestParams.
+     */
+    @discardableResult
+    open func setFilenameOverride(_ filenameOverride: String) -> Self {
+        setParam(UploadRequestParams.FilenameOverride.rawValue, value: filenameOverride)
         return self
     }
     
@@ -1126,5 +1143,6 @@ import Foundation
         case ResponsiveBreakpoints =                "responsive_breakpoints"
         case Ocr =                                  "ocr"
         case BackgroundRemoval =                    "background_removal"
+        case FilenameOverride =                     "filename_override"
     }
 }

--- a/Cloudinary/Classes/Core/Features/Uploader/Results/CLDUploadResult.swift
+++ b/Cloudinary/Classes/Core/Features/Uploader/Results/CLDUploadResult.swift
@@ -158,6 +158,10 @@ import Foundation
         return getParam(.deleteToken) as? String
     }
     
+    open var fileName: String? {
+        return getParam(.filenameOverride) as? String
+    }
+    
     open var info: CLDInfo? {
         guard let info = getParam(.info) as? [String : AnyObject] else {
             return nil

--- a/Cloudinary/Classes/Core/Features/Uploader/Results/CLDUploadResult.swift
+++ b/Cloudinary/Classes/Core/Features/Uploader/Results/CLDUploadResult.swift
@@ -159,7 +159,7 @@ import Foundation
     }
     
     open var fileName: String? {
-        return getParam(.filenameOverride) as? String
+        return getParam(.originalFilename) as? String
     }
     
     open var info: CLDInfo? {

--- a/Cloudinary/Classes/Core/Features/Uploader/Results/CLDUploadResult.swift
+++ b/Cloudinary/Classes/Core/Features/Uploader/Results/CLDUploadResult.swift
@@ -158,7 +158,7 @@ import Foundation
         return getParam(.deleteToken) as? String
     }
     
-    open var fileName: String? {
+    open var originalFilename: String? {
         return getParam(.originalFilename) as? String
     }
     

--- a/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
+++ b/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
@@ -1170,8 +1170,8 @@ class UploaderTests: NetworkBaseTest {
         XCTAssertNotNil(result, "result should not be nil")
         XCTAssertNil(error, "error should be nil")
         
-        if let originalFilenameParam = result?.getParam(.originalFilename) as? String {
-            XCTAssertEqual(originalFilenameParam, "overridden", "Filename mismatch, replaced name should be 'overridden'")
+        if let originalFilename = result?.originalFilename {
+            XCTAssertEqual(originalFilename, "overridden", "Filename mismatch, replaced name should be 'overridden'")
         } else {
             XCTFail("Upload param 'original_filename' is missing")
         }

--- a/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
+++ b/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
@@ -1170,10 +1170,10 @@ class UploaderTests: NetworkBaseTest {
         XCTAssertNotNil(result, "result should not be nil")
         XCTAssertNil(error, "error should be nil")
         
-        if let filenameOverrideParam = result?.getParam(.filenameOverride) as? String {
-            XCTAssertEqual(filenameOverrideParam, "overridden", "Filename mismatch, replaced name should be 'overridden'")
+        if let originalFilenameParam = result?.getParam(.originalFilename) as? String {
+            XCTAssertEqual(originalFilenameParam, "overridden", "Filename mismatch, replaced name should be 'overridden'")
         } else {
-            XCTFail("Upload param 'filename_override' is missing")
+            XCTFail("Upload param 'original_filename' is missing")
         }
     }
 

--- a/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
+++ b/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
@@ -1143,6 +1143,39 @@ class UploaderTests: NetworkBaseTest {
             XCTFail("Error should hold a message in its user info.")
         }
     }
+    
+    func testFilenameOverride() {
+
+        XCTAssertNotNil(cloudinary!.config.apiSecret, "Must set api secret for this test")
+
+        let expectation = self.expectation(description: "Upload should succeed and uploaded filename should change to 'overridden'")
+        let resource: TestResourceType = .borderCollie
+        let file = resource.url
+        var result: CLDUploadResult?
+        var error: NSError?
+
+        let params = CLDUploadRequestParams()
+        params.setFilenameOverride("overridden")
+        params.setUseFilename(true)
+        params.setResourceType(.image)
+        cloudinary!.createUploader().signedUpload(url: file, params: params).response({ (resultRes, errorRes) in
+            result = resultRes
+            error = errorRes
+
+            expectation.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        XCTAssertNotNil(result, "result should not be nil")
+        XCTAssertNil(error, "error should be nil")
+        
+        if let filenameOverrideParam = result?.getParam(.filenameOverride) as? String {
+            XCTAssertEqual(filenameOverrideParam, "overridden", "Filename mismatch, replaced name should be 'overridden'")
+        } else {
+            XCTFail("Upload param 'filename_override' is missing")
+        }
+    }
 
     func testRawConversion() {
 


### PR DESCRIPTION
### Brief Summary of Changes
Added a new param to override an image file name.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
