### PR TITLE
Send tags as an array

### DIFF
--- a/Cloudinary/Classes/Core/Features/ManagementApi/CLDManagementApi.swift
+++ b/Cloudinary/Classes/Core/Features/ManagementApi/CLDManagementApi.swift
@@ -104,7 +104,7 @@ import Foundation
      */
     @discardableResult
     open func addTag(_ tag: String, publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
-        let addTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+        let addTagParams = CLDTagsRequestParams(tags: [tag], publicIds: publicIds)
         addTagParams.merge(params)
         
         let request = networkCoordinator.callAction(.Tags, params: addTagParams.setCommand(.add))
@@ -114,12 +114,12 @@ import Foundation
     }
     
     /**
-     Add a tag to one or more assets in your cloud.
+     Add the tags to one or more assets in your cloud.
      Tags are used to categorize and organize your images, and can also be used to apply group actions to images,
      for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.
      Each image can be assigned one or more tags, which is a short name that you can dynamically use (no need to predefine tags).
      
-     - parameter tags:                  An array of tags to assign
+     - parameter tag:                  An array of tags to assign
      - parameter publicIds:             An array of Public IDs of images uploaded to Cloudinary.
      - parameter params:                An object holding the available parameters for the request.
      - parameter completionHandler:     The closure to be called once the request has finished, holding either the response object or the error.
@@ -129,10 +129,9 @@ import Foundation
                             as well as performing actions on the request, such as cancelling, suspending or resuming it.
      */
     @discardableResult
-    @objc(addTagTags:publicIds:params:completionHandler:)
-    open func addTag(_ tags: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
-        let tag = tags.joined(separator: ",")
-        let addTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+    @objc(addTags:publicIds:params:completionHandler:)
+    open func addTag(_ tag: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
+        let addTagParams = CLDTagsRequestParams(tags: tag, publicIds: publicIds)
         addTagParams.merge(params)
         
         let request = networkCoordinator.callAction(.Tags, params: addTagParams.setCommand(.add))
@@ -158,7 +157,7 @@ import Foundation
      */
     @discardableResult
     open func removeTag(_ tag: String, publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
-        let removeTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+        let removeTagParams = CLDTagsRequestParams(tags: [tag], publicIds: publicIds)
         removeTagParams.merge(params)
         let request = networkCoordinator.callAction(.Tags, params: removeTagParams.setCommand(.remove))
         let tagRequest = CLDTagRequest(networkRequest: request)
@@ -167,12 +166,12 @@ import Foundation
     }
     
     /**
-     Remove a tag to one or more assets in your cloud.
+     Remove tags to one or more assets in your cloud.
      Tags are used to categorize and organize your images, and can also be used to apply group actions to images,
      for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.
      Each image can be assigned one or more tags, which is a short name that you can dynamically use (no need to predefine tags).
      
-     - parameter tags:                  An array of tags to remove
+     - parameter tag:                  An array of tags to remove
      - parameter publicIds:             An array of Public IDs of images uploaded to Cloudinary.
      - parameter params:                An object holding the available parameters for the request.
      - parameter completionHandler:     The closure to be called once the request has finished, holding either the response object or the error.
@@ -182,10 +181,9 @@ import Foundation
      as well as performing actions on the request, such as cancelling, suspending or resuming it.
      */
     @discardableResult
-    @objc(removeTagTags:publicIds:params:completionHandler:)
-    open func removeTag(_ tags: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
-        let tag = tags.joined(separator: ",")
-        let removeTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+    @objc(removeTags:publicIds:params:completionHandler:)
+    open func removeTag(_ tag: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
+        let removeTagParams = CLDTagsRequestParams(tags: tag, publicIds: publicIds)
         removeTagParams.merge(params)
         let request = networkCoordinator.callAction(.Tags, params: removeTagParams.setCommand(.remove))
         let tagRequest = CLDTagRequest(networkRequest: request)
@@ -210,7 +208,33 @@ import Foundation
      */
     @discardableResult
     open func replaceTag(_ tag: String, publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
-        let replaceTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+        let replaceTagParams = CLDTagsRequestParams(tags: [tag], publicIds: publicIds)
+        replaceTagParams.merge(params)
+        let request = networkCoordinator.callAction(.Tags, params: replaceTagParams.setCommand(.replace))
+        let tagRequest = CLDTagRequest(networkRequest: request)
+        tagRequest.response(completionHandler)
+        return tagRequest
+    }
+    
+    /**
+     Replaces tags to one or more assets in your cloud.
+     Tags are used to categorize and organize your images, and can also be used to apply group actions to images,
+     for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.
+     Each image can be assigned one or more tags, which is a short name that you can dynamically use (no need to predefine tags).
+     
+     - parameter tag:                   The array of tags to replace.
+     - parameter publicIds:             An array of Public IDs of images uploaded to Cloudinary.
+     - parameter params:                An object holding the available parameters for the request.
+     - parameter completionHandler:     The closure to be called once the request has finished, holding either the response object or the error.
+     
+     - returns:             An instance of `CLDTagRequest`,
+     allowing the options to add response closure to be called once the request has finished,
+     as well as performing actions on the request, such as cancelling, suspending or resuming it.
+     */
+    @discardableResult
+    @objc(replaceTags:publicIds:params:completionHandler:)
+    open func replaceTag(_ tag: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
+        let replaceTagParams = CLDTagsRequestParams(tags: tag, publicIds: publicIds)
         replaceTagParams.merge(params)
         let request = networkCoordinator.callAction(.Tags, params: replaceTagParams.setCommand(.replace))
         let tagRequest = CLDTagRequest(networkRequest: request)

--- a/Cloudinary/Classes/Core/Features/ManagementApi/CLDManagementApi.swift
+++ b/Cloudinary/Classes/Core/Features/ManagementApi/CLDManagementApi.swift
@@ -119,7 +119,7 @@ import Foundation
      for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.
      Each image can be assigned one or more tags, which is a short name that you can dynamically use (no need to predefine tags).
      
-     - parameter tags:                  An array of tags
+     - parameter tags:                  An array of tags to assign
      - parameter publicIds:             An array of Public IDs of images uploaded to Cloudinary.
      - parameter params:                An object holding the available parameters for the request.
      - parameter completionHandler:     The closure to be called once the request has finished, holding either the response object or the error.
@@ -158,6 +158,33 @@ import Foundation
      */
     @discardableResult
     open func removeTag(_ tag: String, publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
+        let removeTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+        removeTagParams.merge(params)
+        let request = networkCoordinator.callAction(.Tags, params: removeTagParams.setCommand(.remove))
+        let tagRequest = CLDTagRequest(networkRequest: request)
+        tagRequest.response(completionHandler)
+        return tagRequest
+    }
+    
+    /**
+     Remove a tag to one or more assets in your cloud.
+     Tags are used to categorize and organize your images, and can also be used to apply group actions to images,
+     for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.
+     Each image can be assigned one or more tags, which is a short name that you can dynamically use (no need to predefine tags).
+     
+     - parameter tags:                  An array of tags to remove
+     - parameter publicIds:             An array of Public IDs of images uploaded to Cloudinary.
+     - parameter params:                An object holding the available parameters for the request.
+     - parameter completionHandler:     The closure to be called once the request has finished, holding either the response object or the error.
+     
+     - returns:             An instance of `CLDTagRequest`,
+     allowing the options to add response closure to be called once the request has finished,
+     as well as performing actions on the request, such as cancelling, suspending or resuming it.
+     */
+    @discardableResult
+    @objc(removeTagTags:publicIds:params:completionHandler:)
+    open func removeTag(_ tags: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
+        let tag = tags.joined(separator: ",")
         let removeTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
         removeTagParams.merge(params)
         let request = networkCoordinator.callAction(.Tags, params: removeTagParams.setCommand(.remove))

--- a/Cloudinary/Classes/Core/Features/ManagementApi/CLDManagementApi.swift
+++ b/Cloudinary/Classes/Core/Features/ManagementApi/CLDManagementApi.swift
@@ -114,6 +114,34 @@ import Foundation
     }
     
     /**
+     Add a tag to one or more assets in your cloud.
+     Tags are used to categorize and organize your images, and can also be used to apply group actions to images,
+     for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.
+     Each image can be assigned one or more tags, which is a short name that you can dynamically use (no need to predefine tags).
+     
+     - parameter tags:                  An array of tags
+     - parameter publicIds:             An array of Public IDs of images uploaded to Cloudinary.
+     - parameter params:                An object holding the available parameters for the request.
+     - parameter completionHandler:     The closure to be called once the request has finished, holding either the response object or the error.
+     
+     - returns:             An instance of `CLDTagRequest`,
+                            allowing the options to add response closure to be called once the request has finished,
+                            as well as performing actions on the request, such as cancelling, suspending or resuming it.
+     */
+    @discardableResult
+    @objc(addTagTags:publicIds:params:completionHandler:)
+    open func addTag(_ tags: [String], publicIds: [String], params: CLDTagsRequestParams? = nil, completionHandler: ((_ result: CLDTagResult?, _ error: Error?) -> ())? = nil) -> CLDTagRequest {
+        let tag = tags.joined(separator: ",")
+        let addTagParams = CLDTagsRequestParams(tag: tag, publicIds: publicIds)
+        addTagParams.merge(params)
+        
+        let request = networkCoordinator.callAction(.Tags, params: addTagParams.setCommand(.add))
+        let tagRequest = CLDTagRequest(networkRequest: request)
+        tagRequest.response(completionHandler)
+        return tagRequest
+    }
+    
+    /**
      Remove a tag to one or more assets in your cloud.
      Tags are used to categorize and organize your images, and can also be used to apply group actions to images,
      for example to delete images, create sprites, ZIP files, JSON lists, or animated GIFs.

--- a/Cloudinary/Classes/Core/Features/ManagementApi/RequestsParams/CLDTagsRequestParams.swift
+++ b/Cloudinary/Classes/Core/Features/ManagementApi/RequestsParams/CLDTagsRequestParams.swift
@@ -42,9 +42,9 @@ import Foundation
     
     - returns:                       A new instance of CLDTagsRequestParams.
     */
-    internal init(tag: String, publicIds: [String]) {
+    internal init(tags: [String], publicIds: [String]) {
         super.init()
-        setParam(TagsParams.Tag.rawValue, value: tag)
+        setParam(TagsParams.Tag.rawValue, value: tags.joined(separator: ","))
         setParam(TagsParams.PublicIds.rawValue, value: publicIds)
     }
     

--- a/Example/Tests/NetworkTests/ManagementApiTests.swift
+++ b/Example/Tests/NetworkTests/ManagementApiTests.swift
@@ -270,6 +270,24 @@ class ManagementApiTests: NetworkBaseTest {
 
         XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
         
+        // Reaplace tag
+        result = nil
+        error = nil
+        expectation = self.expectation(description: "Replacing a tag should succeed")
+        let replacedTag = ["replaced_tag", "replaced_tag2"]
+        cloudinary!.createManagementApi().replaceTag(replacedTag, publicIds: [uploadedPublicId]) { (resultRes, errorRes) in
+            result = resultRes
+            error = errorRes
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNotNil(result, "result should not be nil")
+
+        XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
+        
         // Remove tags
         result = nil
         error = nil

--- a/Example/Tests/NetworkTests/ManagementApiTests.swift
+++ b/Example/Tests/NetworkTests/ManagementApiTests.swift
@@ -239,7 +239,7 @@ class ManagementApiTests: NetworkBaseTest {
     func testTagsAsArray() {
         let tagsArray = ["tag1","tag2","tag3"]
         
-        var expectation = self.expectation(description: "Adding a tag should succeed")
+        var expectation = self.expectation(description: "Adding tags as an array should succeed")
         
         var result: CLDTagResult?
         var error: Error?
@@ -273,7 +273,7 @@ class ManagementApiTests: NetworkBaseTest {
         // Reaplace tag
         result = nil
         error = nil
-        expectation = self.expectation(description: "Replacing a tag should succeed")
+        expectation = self.expectation(description: "Replacing tags as an array should succeed")
         let replacedTag = ["replaced_tag", "replaced_tag2"]
         cloudinary!.createManagementApi().replaceTag(replacedTag, publicIds: [uploadedPublicId]) { (resultRes, errorRes) in
             result = resultRes
@@ -291,7 +291,7 @@ class ManagementApiTests: NetworkBaseTest {
         // Remove tags
         result = nil
         error = nil
-        expectation = self.expectation(description: "Removing a tag should succeed")
+        expectation = self.expectation(description: "Removing tags as an array should succeed")
         cloudinary!.createManagementApi().removeTag(tagsArray, publicIds: [uploadedPublicId]) { (resultRes, errorRes) in
             result = resultRes
             error = errorRes

--- a/Example/Tests/NetworkTests/ManagementApiTests.swift
+++ b/Example/Tests/NetworkTests/ManagementApiTests.swift
@@ -250,7 +250,7 @@ class ManagementApiTests: NetworkBaseTest {
             if let pubId = uploadResult?.publicId {
                 uploadedPublicId = pubId
                 
-                // test adding a tag
+                // test adding a tags
                 self.cloudinary!.createManagementApi().addTag(tagsArray, publicIds: [uploadedPublicId]).response({ (resultRes, errorRes) in
                     result = resultRes
                     error = errorRes
@@ -270,7 +270,7 @@ class ManagementApiTests: NetworkBaseTest {
 
         XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
         
-        // Remove tag
+        // Remove tags
         result = nil
         error = nil
         expectation = self.expectation(description: "Removing a tag should succeed")

--- a/Example/Tests/NetworkTests/ManagementApiTests.swift
+++ b/Example/Tests/NetworkTests/ManagementApiTests.swift
@@ -237,6 +237,8 @@ class ManagementApiTests: NetworkBaseTest {
     }
     
     func testTagsAsArray() {
+        let tagsArray = ["tag1","tag2","tag3"]
+        
         var expectation = self.expectation(description: "Adding a tag should succeed")
         
         var result: CLDTagResult?
@@ -249,7 +251,7 @@ class ManagementApiTests: NetworkBaseTest {
                 uploadedPublicId = pubId
                 
                 // test adding a tag
-                self.cloudinary!.createManagementApi().addTag(["tag1","tag2","tag3"], publicIds: [uploadedPublicId]).response({ (resultRes, errorRes) in
+                self.cloudinary!.createManagementApi().addTag(tagsArray, publicIds: [uploadedPublicId]).response({ (resultRes, errorRes) in
                     result = resultRes
                     error = errorRes
                     expectation.fulfill()
@@ -267,7 +269,27 @@ class ManagementApiTests: NetworkBaseTest {
         XCTAssertNotNil(result, "result should not be nil")
 
         XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
+        
+        // Remove tag
+        result = nil
+        error = nil
+        expectation = self.expectation(description: "Removing a tag should succeed")
+        cloudinary!.createManagementApi().removeTag(tagsArray, publicIds: [uploadedPublicId]) { (resultRes, errorRes) in
+            result = resultRes
+            error = errorRes
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNotNil(result, "result should not be nil")
+
+        XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
     }
+    
+    
+    
     
     // MARK: - text
     func testGenerateText() {

--- a/Example/Tests/NetworkTests/ManagementApiTests.swift
+++ b/Example/Tests/NetworkTests/ManagementApiTests.swift
@@ -236,6 +236,39 @@ class ManagementApiTests: NetworkBaseTest {
         XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
     }
     
+    func testTagsAsArray() {
+        var expectation = self.expectation(description: "Adding a tag should succeed")
+        
+        var result: CLDTagResult?
+        var error: Error?
+        
+        var uploadedPublicId: String = ""
+        // first upload
+        uploadFile().response({ (uploadResult, uploadError) in
+            if let pubId = uploadResult?.publicId {
+                uploadedPublicId = pubId
+                
+                // test adding a tag
+                self.cloudinary!.createManagementApi().addTag(["tag1","tag2","tag3"], publicIds: [uploadedPublicId]).response({ (resultRes, errorRes) in
+                    result = resultRes
+                    error = errorRes
+                    expectation.fulfill()
+                })
+            }
+            else {
+                error = uploadError
+                expectation.fulfill()
+            }
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        XCTAssertNil(error, "error should be nil")
+        XCTAssertNotNil(result, "result should not be nil")
+
+        XCTAssertEqual(result?.publicIds?.first ?? "", uploadedPublicId)
+    }
+    
     // MARK: - text
     func testGenerateText() {
         


### PR DESCRIPTION
### Brief Summary of Changes
Add functionality to send tags as an array and not only as string to both `addTag` and `removeTag` functions

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
