### PR TITLE
Fix expression normalize for user variables

### DIFF
--- a/Cloudinary/Classes/Core/Features/Helpers/CLDExpression.swift
+++ b/Cloudinary/Classes/Core/Features/Helpers/CLDExpression.swift
@@ -36,9 +36,9 @@ import Foundation
         case initial_height
         case initialHeight
         
+        case initial_aspect_ratio
         case aspect_ratio
         case aspectRatio
-        case initial_aspect_ratio
         case initialAspectRatio
         
         case page_count
@@ -73,9 +73,9 @@ import Foundation
             case .initial_height: return "ih"
             case .initialHeight : return "ih"
                 
+            case .initial_aspect_ratio: return "iar"
             case .aspect_ratio        : return "ar"
             case .aspectRatio         : return "ar"
-            case .initial_aspect_ratio: return "iar"
             case .initialAspectRatio  : return "iar"
                 
             case .page_count: return "pc"
@@ -106,7 +106,9 @@ import Foundation
     internal var currentKey        : String
     
     private let consecutiveDashesRegex: String = "[ _]+"
-    
+    private let consecutiveSpaceRegex: String = "[  ]+"
+    private let userVariableRegex: String = "\\$_*[^_]+"
+
     // MARK: - Init
     public override init() {
         self.currentKey   = String()
@@ -117,7 +119,7 @@ import Foundation
     public init(value: String) {
         var components = value.components(separatedBy: .whitespacesAndNewlines)
         self.currentKey   = components.removeFirst()
-        self.currentValue = components.joined(separator: CLDVariable.elementsSeparator)
+        self.currentValue = value == " " ? "_" : components.joined(separator: CLDVariable.elementsSeparator)
         super.init()
     }
     
@@ -286,14 +288,20 @@ import Foundation
     // MARK: - provide content
     public func asString() -> String {
         
-        guard !currentKey.isEmpty else { return String() }
-        
-        let key = replaceAllExpressionKeys(in: currentKey)
-        
+        guard !currentKey.isEmpty else {
+            if !currentValue.isEmpty {
+                return removeExtraSpaces(from: removeExtraDashes(from: replaceAllUnicodeChars(in: currentValue)))
+            }
+            return String()
+
+        }
+
+        let key = removeExtraDashes(from: replaceAllExpressionKeys(in: currentKey))
+
         if currentValue.isEmpty {
             return "\(key)"
         }
-        let value = removeExtraDashes(from: replaceAllUnencodeChars(in: currentValue))
+        let value = removeExtraDashes(from: replaceAllUnicodeChars(in: currentValue))
         return "\(key)_\(value)"
     }
     
@@ -305,7 +313,7 @@ import Foundation
         }
         
         let key   = replaceAllExpressionKeys(in: currentKey)
-        let value = removeExtraDashes(from: replaceAllUnencodeChars(in: currentValue))
+        let value = removeExtraDashes(from: replaceAllUnicodeChars(in: currentValue))
         
         return [key:value]
     }
@@ -320,7 +328,7 @@ import Foundation
     }
     
     // MARK: - Private methods
-    private func replaceAllUnencodeChars(in string: String) -> String {
+    private func replaceAllUnicodeChars(in string: String) -> String {
         
         var wipString   = string
         wipString       = replaceAllOperators(in: string)
@@ -353,26 +361,34 @@ import Foundation
         
         return wipString
     }
-    
+
     private func replace(expressionKey: ExpressionKeys, in string: String) -> String {
-        
-        var result : String
-        
+
+        var result : String!
+
         if string.contains(CLDVariable.variableNamePrefix) {
-            
-            result = string.components(separatedBy: CLDVariable.elementsSeparator).map({
-                
-                let temp : String
-                switch $0.hasPrefix(CLDVariable.variableNamePrefix) {
-                case true : temp = $0
-                case false: temp = $0.replacingOccurrences(of: expressionKey.rawValue, with: expressionKey.asString)
+            let string = removeExtraDashes(from: string)
+            let range = NSRange(location: 0, length: string.utf16.count)
+            let regex = try? NSRegularExpression(pattern: userVariableRegex)
+            let allRanges = regex?.matches(in: removeExtraDashes(from: string), options: [], range: range).map({ $0.range }) ?? []
+
+            // Replace substring in between user variables. e.x $initial_aspect_ratio_$width, only '_aspect_ratio_' will be addressed.
+            for (index, range) in allRanges.enumerated() {
+                let location = range.length + range.location
+                var length = range.length
+
+                if index + 1 == allRanges.count {
+                    length = string.count
+                } else {
+                    let nextRange = allRanges[index + 1]
+                    length = nextRange.location
                 }
-                return temp
-                
-            }).joined(separator: CLDVariable.elementsSeparator)
-            
+
+                if let stringRange = Range(NSRange(location: location, length: length - location), in: string) {
+                    result = string.replacingOccurrences(of: expressionKey.rawValue, with: expressionKey.asString, options: .regularExpression, range: stringRange)
+                }
+            }
         } else {
-            
             result = string.replacingOccurrences(of: expressionKey.rawValue, with: expressionKey.asString)
         }
         return result
@@ -403,4 +419,17 @@ import Foundation
     private func removeExtraDashes(from string: String) -> String {
         return string.replacingOccurrences(of: consecutiveDashesRegex, with: CLDVariable.elementsSeparator, options: .regularExpression, range: nil)
     }
+
+    private func removeExtraSpaces(from string: String) -> String {
+        let regex = try? NSRegularExpression(pattern: consecutiveSpaceRegex)
+        let range = NSRange(location: 0, length: string.utf16.count)
+        let isStringOnlySpaces = regex?.firstMatch(in: string, options: [], range: range) != nil
+
+        if isStringOnlySpaces == true {
+            return "_"
+        }
+
+        return string.replacingOccurrences(of: consecutiveSpaceRegex, with: CLDVariable.elementsSeparator, options: .regularExpression, range: nil)
+    }
 }
+

--- a/Example/Tests/TransformationTests/CLDExpressionTests/CLDExpressionTests.swift
+++ b/Example/Tests/TransformationTests/CLDExpressionTests/CLDExpressionTests.swift
@@ -877,4 +877,362 @@ class CLDExpressionTests: BaseTestCase {
         // Then
         XCTAssertEqual(actualResult, expectedResult, "Calling asParams, should remove extra dashes/spaces")
     }
+
+    func test_powerString_shouldAppendValidValuex() {
+        // Given
+        let name = "$________height"
+        let initialValue = "$_____width"
+        let value = "30.3"
+
+        let expectedValueResult = "$_height_$_width_pow_30.3"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(initialValue)").power(by: value)
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+    func testExpressionNumber() {
+        // Given
+        let name = 10
+        let expectedValueResult = "10"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+    func testExpressionSingleSpace_underscore() {
+        // Given
+        let name = " "
+        let expectedValueResult = "_"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionBlankString_underscore() {
+        // Given
+        let name = "  "
+        let expectedValueResult = "_"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionUnderscore_underscore() {
+        // Given
+        let name = "_"
+        let expectedValueResult = "_"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionUnderscores_underscore() {
+        // Given
+        let name = "___"
+        let expectedValueResult = "_"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionUnderscoresAndSpaces_underscore() {
+        // Given
+        let name = " _ __  _"
+        let expectedValueResult = "_"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionArbitraryText_isNotAffected() {
+        // Given
+        let name = "foobar"
+        let expectedValueResult = "foobar"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoubleAmpersand_replacedWithAndOperator() {
+        // Given
+        let name = "foo && bar"
+        let expectedValueResult = "foo_and_bar"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoubleAmpersandWithNoSpaceAtEnd_isNotAffected() {
+        // Given
+        let name = "foo&&bar"
+        let expectedValueResult = "foo&&bar"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionWidth_recognizedAsVariableAndReplacedWithW() {
+        // Given
+        let name = "width"
+        let expectedValueResult = "w"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionInitialAspectRatio_recognizedAsVariableAndReplacedWithW() {
+        // Given
+        let name = "width"
+        let expectedValueResult = "w"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDollarWidth_recognizedAsUserVariableAndNotAffected() {
+        // Given
+        let name = "$width"
+        let expectedValueResult = "$width"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDollarInitialAspectRatio_recognizedAsUserVariableAndAsVariableReplacedWithAr() {
+        // Given
+        let name = "$initial_aspect_ratio"
+        let expectedValueResult = "$initial_ar"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDollarMyWidth_recognizedAsUserVariableAndNotAffected() {
+        // Given
+        let name = "$mywidth"
+        let expectedValueResult = "$mywidth"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDollarWidthWidth_recognizedAsUserVariableAndNotAffected() {
+        // Given
+        let name = "$widthwidth"
+        let expectedValueResult = "$widthwidth"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDollarUnderscoreWidth_recognizedAsUserVariableAndNotAffected() {
+        // Given
+        let name = "$_width"
+        let expectedValueResult = "$_width"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+    func testExpressionDollarUnderscoreX2Width_recognizedAsUserVariableAndNotAffected() {
+        // Given
+        let name = "$__width"
+        let expectedValueResult = "$_width"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDollarX2Width_recognizedAsUserVariableAndNotAffected() {
+        // Given
+        let name = "$\\$width"
+        let expectedValueResult = "$\\$width"
+
+        // When
+        sut = CLDExpression(value: "\(name)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_1() {
+        // Given
+        let name = "$height"
+        let value = "100"
+        let expectedValueResult = "$height_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_2() {
+        // Given
+        let name = "$heightt"
+        let value = "100"
+        let expectedValueResult = "$heightt_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_3() {
+        // Given
+        let name = "$\\$height"
+        let value = "100"
+        let expectedValueResult = "$\\$height_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_4() {
+        // Given
+        let name = "$heightmy"
+        let value = "100"
+        let expectedValueResult = "$heightmy_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_5() {
+        // Given
+        let name = "$myheight"
+        let value = "100"
+        let expectedValueResult = "$myheight_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_6() {
+        // Given
+        let name = "$heightheight"
+        let value = "100"
+        let expectedValueResult = "$heightheight_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_7() {
+        // Given
+        let name = "$theheight"
+        let value = "100"
+        let expectedValueResult = "$theheight_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
+
+
+    func testExpressionDoesntReplaceVariable_8() {
+        // Given
+        let name = "$________height"
+        let value = "100"
+        let expectedValueResult = "$_height_100"
+
+        // When
+        sut = CLDExpression(value: "\(name) \(value)")
+
+        // Then
+        XCTAssertEqual(sut.asString(), expectedValueResult, "string should be equal to expectedValueResult")
+    }
 }


### PR DESCRIPTION
### Brief Summary of Changes
Fix normalize function to not trim user variables such as: $width to $w
Add tests to verify edge cases

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
