### PR TITLE
Add support for `startOffset` and `endOffset` as expression

### DIFF
--- a/Cloudinary/Classes/Core/Features/Helpers/CLDTransformation.swift
+++ b/Cloudinary/Classes/Core/Features/Helpers/CLDTransformation.swift
@@ -2184,6 +2184,20 @@ extension CLDTransformation
         
         return setParam(TransformationParam.RADIUS, value: input.asString())
     }
+    
+    @objc(setStartOffsetFromExpression:)
+    @discardableResult
+    public func setStartOffset(_ input: CLDExpression) -> Self {
+        
+        return setParam(TransformationParam.START_OFFSET, value: input.asString())
+    }
+    
+    @objc(setEndOffsetFromExpression:)
+    @discardableResult
+    public func setEndOffset(_ input: CLDExpression) -> Self {
+        
+        return setParam(TransformationParam.END_OFFSET, value: input.asString())
+    }
 }
 // MARK: - Condition Expression
 extension CLDTransformation

--- a/Example/Tests/TransformationTests/CLDTransformationTests/CLDTransformationExpressionsTests.swift
+++ b/Example/Tests/TransformationTests/CLDTransformationTests/CLDTransformationExpressionsTests.swift
@@ -160,10 +160,10 @@ class CLDTransformationExpressionsTests: BaseTestCase {
     func test_setStartOffset_inputExpression_shouldStoreNewValue() {
         
         // Given
-        let input       = "initialHeight * 2"
+        let input       = "duration - 3"
         let expression  = CLDExpression(value: input)
         
-        let expectedResult = "ih_mul_2"
+        let expectedResult = "du_sub_3"
         
         // When
         sut.setStartOffset(expression)
@@ -171,8 +171,8 @@ class CLDTransformationExpressionsTests: BaseTestCase {
         let actualResult = sut.startOffset!
         
         // Then
-        XCTAssertFalse(actualResult.isEmpty, "x should stored new value")
-        XCTAssertEqual(actualResult, expectedResult, "Calling get x should return its value")
+        XCTAssertFalse(actualResult.isEmpty, "actualy result should not be empty")
+        XCTAssertEqual(actualResult, expectedResult, "acutalyResult and expectedResult should be eqaul")
     }
     
     func test_setEndOffset_emptyInputParamaters_shouldNotStoreNewVariable() {
@@ -193,10 +193,10 @@ class CLDTransformationExpressionsTests: BaseTestCase {
     func test_setEndOffset_inputExpression_shouldStoreNewValue() {
         
         // Given
-        let input       = "initialHeight * 2"
+        let input       = "duration - 3"
         let expression  = CLDExpression(value: input)
         
-        let expectedResult = "ih_mul_2"
+        let expectedResult = "du_sub_3"
         
         // When
         sut.setEndOffset(expression)
@@ -204,8 +204,8 @@ class CLDTransformationExpressionsTests: BaseTestCase {
         let actualResult = sut.endOffset!
         
         // Then
-        XCTAssertFalse(actualResult.isEmpty, "x should stored new value")
-        XCTAssertEqual(actualResult, expectedResult, "Calling get x should return its value")
+        XCTAssertFalse(actualResult.isEmpty, "actualy result should not be empty")
+        XCTAssertEqual(actualResult, expectedResult, "acutalyResult and expectedResult should be eqaul")
     }
     
     func test_setY_emptyInputParamaters_shouldNotStoreNewVariable() {

--- a/Example/Tests/TransformationTests/CLDTransformationTests/CLDTransformationExpressionsTests.swift
+++ b/Example/Tests/TransformationTests/CLDTransformationTests/CLDTransformationExpressionsTests.swift
@@ -142,6 +142,72 @@ class CLDTransformationExpressionsTests: BaseTestCase {
         XCTAssertEqual(actualResult, expectedResult, "Calling get x should return its value")
     }
     
+    func test_setStartOffset_emptyInputParamaters_shouldNotStoreNewVariable() {
+        
+        // Given
+        let input       = String()
+        let expression  = CLDExpression(value: input)
+        
+        // When
+        sut.setStartOffset(expression)
+        
+        let actualResult = sut.startOffset!
+        
+        // Then
+        XCTAssertTrue(actualResult.isEmpty, "Empty expression should not be stored in params")
+    }
+    
+    func test_setStartOffset_inputExpression_shouldStoreNewValue() {
+        
+        // Given
+        let input       = "initialHeight * 2"
+        let expression  = CLDExpression(value: input)
+        
+        let expectedResult = "ih_mul_2"
+        
+        // When
+        sut.setStartOffset(expression)
+        
+        let actualResult = sut.startOffset!
+        
+        // Then
+        XCTAssertFalse(actualResult.isEmpty, "x should stored new value")
+        XCTAssertEqual(actualResult, expectedResult, "Calling get x should return its value")
+    }
+    
+    func test_setEndOffset_emptyInputParamaters_shouldNotStoreNewVariable() {
+        
+        // Given
+        let input       = String()
+        let expression  = CLDExpression(value: input)
+        
+        // When
+        sut.setEndOffset(expression)
+        
+        let actualResult = sut.endOffset!
+        
+        // Then
+        XCTAssertTrue(actualResult.isEmpty, "Empty expression should not be stored in params")
+    }
+    
+    func test_setEndOffset_inputExpression_shouldStoreNewValue() {
+        
+        // Given
+        let input       = "initialHeight * 2"
+        let expression  = CLDExpression(value: input)
+        
+        let expectedResult = "ih_mul_2"
+        
+        // When
+        sut.setEndOffset(expression)
+        
+        let actualResult = sut.endOffset!
+        
+        // Then
+        XCTAssertFalse(actualResult.isEmpty, "x should stored new value")
+        XCTAssertEqual(actualResult, expectedResult, "Calling get x should return its value")
+    }
+    
     func test_setY_emptyInputParamaters_shouldNotStoreNewVariable() {
         
         // Given

--- a/Example/Tests/TransformationTests/CLDTransformationTests/CLDTransformationExpressionsTests.swift
+++ b/Example/Tests/TransformationTests/CLDTransformationTests/CLDTransformationExpressionsTests.swift
@@ -171,8 +171,8 @@ class CLDTransformationExpressionsTests: BaseTestCase {
         let actualResult = sut.startOffset!
         
         // Then
-        XCTAssertFalse(actualResult.isEmpty, "actualy result should not be empty")
-        XCTAssertEqual(actualResult, expectedResult, "acutalyResult and expectedResult should be eqaul")
+        XCTAssertFalse(actualResult.isEmpty, "actualResult should not be empty")
+        XCTAssertEqual(actualResult, expectedResult, "actualResult and expectedResult should be equal")
     }
     
     func test_setEndOffset_emptyInputParamaters_shouldNotStoreNewVariable() {
@@ -204,8 +204,8 @@ class CLDTransformationExpressionsTests: BaseTestCase {
         let actualResult = sut.endOffset!
         
         // Then
-        XCTAssertFalse(actualResult.isEmpty, "actualy result should not be empty")
-        XCTAssertEqual(actualResult, expectedResult, "acutalyResult and expectedResult should be eqaul")
+        XCTAssertFalse(actualResult.isEmpty, "actualResult should not be empty")
+        XCTAssertEqual(actualResult, expectedResult, "actualResult and expectedResult should be equal")
     }
     
     func test_setY_emptyInputParamaters_shouldNotStoreNewVariable() {


### PR DESCRIPTION
### Brief Summary of Changes
Add support for `startOffset` and `endOffset` as expression

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
