### PR TITLE
Fix credStore warning

### DIFF
--- a/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionManager.swift
+++ b/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionManager.swift
@@ -165,6 +165,7 @@ internal class CLDNSessionManager {
         configuration: URLSessionConfiguration = URLSessionConfiguration.default,
         delegate: CLDNSessionDelegate = CLDNSessionDelegate())
     {
+        configuration.urlCredentialStorage = nil;
         self.delegate = delegate
         self.session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
 


### PR DESCRIPTION
### Brief Summary of Changes
Fix for cred store warning by initialsing urlCredentialStorage to nil.

#### What does this PR address?
- [x] GitHub issue (Add reference - #[252](https://github.com/cloudinary/cloudinary_ios/issues/252))
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
