### PR TITLE
Make upload request respect timeout

### DIFF
--- a/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionManager.swift
+++ b/Cloudinary/Classes/Core/BaseNetwork/CLDNSessionManager.swift
@@ -470,11 +470,14 @@ internal class CLDNSessionManager {
         method: CLDNHTTPMethod = .post,
         headers: CLDNHTTPHeaders? = nil,
         queue: DispatchQueue? = nil,
+        timeout: NSNumber? = nil,
         encodingCompletion: ((MultipartFormDataEncodingResult) -> Void)?)
     {
         do {
-            let urlRequest = try URLRequest(url: url, method: method, headers: headers)
-
+            var urlRequest = try URLRequest(url: url, method: method, headers: headers)
+            if let timeout = timeout {
+                urlRequest.timeoutInterval = timeout.doubleValue
+            }
             return upload(
                 multipartFormData: multipartFormData,
                 usingThreshold: encodingMemoryThreshold,

--- a/Cloudinary/Classes/Core/Network/CLDDefaultNetworkAdapter.swift
+++ b/Cloudinary/Classes/Core/Network/CLDDefaultNetworkAdapter.swift
@@ -63,7 +63,8 @@ internal class CLDDefaultNetworkAdapter: NSObject, CLDNetworkAdapter {
     }
 
     internal func uploadToCloudinary(_ url: String, headers: [String: String], parameters: [String: Any], data: Any) -> CLDNetworkDataRequest {
-
+        var parameters = parameters
+        let timeout = parameters.removeValue(forKey: "timeout") as? NSNumber
         let asyncUploadRequest = CLDAsyncNetworkUploadRequest()
         manager.upload(multipartFormData: { (multipartFormData) in
 
@@ -103,7 +104,7 @@ internal class CLDDefaultNetworkAdapter: NSObject, CLDNetworkAdapter {
                 }
             }
 
-        }, usingThreshold: UInt64(), to: url, method: .post, headers: headers) { (encodingResult) in
+        }, usingThreshold: UInt64(), to: url, method: .post, headers: headers, timeout: timeout) { (encodingResult) in
             switch encodingResult {
             case .success(let upload, _, _):
                 upload.resume()

--- a/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift
+++ b/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift
@@ -64,6 +64,7 @@ internal class CLDNetworkCoordinator: NSObject {
     
     internal func upload(_ data: Any, params: CLDUploadRequestParams, extraHeaders: [String:String]?=[:]) -> CLDNetworkDataRequest {
         let url = getUrl(.Upload, resourceType: params.resourceType)
+        params.setTimeout(from: config)
         let requestParams = params.signed ? getSignedRequestParams(params) : params.params
         var headers :[String : String] = getHeaders()
         headers.cldMerge(extraHeaders)

--- a/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
+++ b/Example/Tests/NetworkTests/UploaderTests/UploaderTests.swift
@@ -53,6 +53,71 @@ class UploaderTests: NetworkBaseTest {
         XCTAssertNotNil(result, "result should not be nil")
         XCTAssertNil(error, "error should be nil")
     }
+
+    func testUploadRespectTimeoutFromConfiguration() {
+        XCTAssertNotNil(cloudinary!.config.apiSecret, "Must set api secret for this test")
+
+        let expectedResult = "-1001"
+        let expectation = self.expectation(description: "upload should fail")
+        let data = TestResourceType.borderCollie.data
+
+        var result: CLDUploadResult?
+        var error: NSError?
+
+        let params = CLDUploadRequestParams()
+        params.setColors(true)
+        cloudinaryInsufficientTimeout!.createUploader().signedUpload(data: data, params: params).response({ (resultRes, errorRes) in
+            result = resultRes
+            error = errorRes
+
+            expectation.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        var actualResult = String()
+
+        if let error = error {
+            actualResult = String((error as NSError).code)
+        }
+
+        XCTAssertNotNil(error, "error should not be nil")
+        XCTAssertNil(result, "response should be nil")
+        XCTAssertEqual(actualResult, expectedResult, "error should occur due to timeout")
+    }
+
+    func testUploadRespectTimeoutFromParameters() {
+        XCTAssertNotNil(cloudinary!.config.apiSecret, "Must set api secret for this test")
+
+        let expectedResult = "-1001"
+        let expectation = self.expectation(description: "upload should fail")
+        let data = TestResourceType.borderCollie.data
+
+        var result: CLDUploadResult?
+        var error: NSError?
+
+        let params = CLDUploadRequestParams()
+        params.setColors(true)
+        params.setTimeout(from: cloudinaryInsufficientTimeout!.config)
+        cloudinaryInsufficientTimeout!.createUploader().signedUpload(data: data, params: params).response({ (resultRes, errorRes) in
+            result = resultRes
+            error = errorRes
+
+            expectation.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        var actualResult = String()
+
+        if let error = error {
+            actualResult = String((error as NSError).code)
+        }
+
+        XCTAssertNotNil(error, "error should not be nil")
+        XCTAssertNil(result, "response should be nil")
+        XCTAssertEqual(actualResult, expectedResult, "error should occur due to timeout")
+    }
     
     func testUploadPNGImageData() {
 


### PR DESCRIPTION
### Brief Summary of Changes
This PR comes to fix an issue where the timeout set into Cloudinary's config is not respected by the upload function

#### What does this PR address?
- [ ] GitHub issue (Add reference - #396 )
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [x] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
