### PR TITLE
Turn on CLDUrlCache on by default, old image cache off by default

### DIFF
--- a/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift
+++ b/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift
@@ -197,6 +197,8 @@ class CLDDownloadCoordinator: CLDNetworkCoordinator, CLDURLCacheDelegate {
         let downloadConfiguration                   = URLSessionConfiguration.default
         downloadConfiguration.httpAdditionalHeaders = CLDNSessionManager.defaultHTTPHeaders
         downloadConfiguration.urlCache              = urlCache
+        // Turn urlCache as default
+        urlCache.shouldIncludeImages(true)
         
         let downloadAdapter = CLDDefaultNetworkAdapter(configuration: downloadConfiguration)
         

--- a/Cloudinary/Classes/Core/Utils/CLDImageCache.swift
+++ b/Cloudinary/Classes/Core/Utils/CLDImageCache.swift
@@ -44,7 +44,7 @@ internal struct Defines {
 
 internal class CLDImageCache {
     
-    internal var cachePolicy = CLDImageCachePolicy.disk
+    internal var cachePolicy = CLDImageCachePolicy.none
     
     fileprivate let memoryCache = NSCache<NSString, UIImage>()
     internal var maxMemoryTotalCost: Int = Defines.defaultMemoryTotalCostLimit {

--- a/Example/Tests/BaseNetwork/Core/CLDCloudinaryTests.swift
+++ b/Example/Tests/BaseNetwork/Core/CLDCloudinaryTests.swift
@@ -132,7 +132,8 @@ class CLDCloudinaryTests: XCTestCase {
     func test_init_defaultVaues_shouldBeEqualToExpectedValues() {
         
         // Given
-        let defaultCachePolicy            : CLDImageCachePolicy = .disk
+        let defaultCachePolicy            : CLDImageCachePolicy = .none
+        let defaultUrlCachePolicy         : Bool = true
         let defaultCacheMaxDiskCapacity   : UInt64              = 150 * 1024 * 1024
         let defaultCacheMaxMemoryTotalCost: Int                 = 30 * 1024 * 1024
         
@@ -140,6 +141,7 @@ class CLDCloudinaryTests: XCTestCase {
         XCTAssertNotNil(sut, "initialized object should not be nil")
         XCTAssertEqual (sut.config, config, "Initilized object should contain expected value")
         XCTAssertEqual (sut.cachePolicy, defaultCachePolicy, "Initilized object should contain expected value")
+        XCTAssertEqual(sut.enableUrlCache, defaultUrlCachePolicy)
         XCTAssertEqual (sut.cacheMaxDiskCapacity, defaultCacheMaxDiskCapacity, "Initilized object should contain expected value")
         XCTAssertEqual (sut.cacheMaxMemoryTotalCost, defaultCacheMaxMemoryTotalCost, "Initilized object should contain expected value")
     }

--- a/Example/Tests/NetworkTests/DownloaderTests.swift
+++ b/Example/Tests/NetworkTests/DownloaderTests.swift
@@ -102,6 +102,8 @@ class DownloaderTests: NetworkBaseTest {
         XCTAssertNil(error, "error should be nil")
     }
     func test_downloadImageWithCache_shouldCacheAndRemoveImage() {
+        cloudinarySecured.enableUrlCache = false
+        cloudinarySecured.cachePolicy = .disk
         downloadImageWithCache_shouldCacheImage(cloudinaryObject: cloudinarySecured)
     }
     func test_downloadImageWithoutCache_shouldCacheImage() {
@@ -120,7 +122,9 @@ class DownloaderTests: NetworkBaseTest {
 
         // When
         let tempSut = CLDCloudinary(configuration: config, networkAdapter: nil, downloadAdapter: nil, sessionConfiguration: nil, downloadSessionConfiguration: nil)
-            
+        tempSut.enableUrlCache = false
+        tempSut.cachePolicy = .disk
+        
         downloadImageWithCache_shouldCacheImage(cloudinaryObject: tempSut)
     }
     func test_downloadImageWithoutCache_emptyInit_shouldCacheImage() {


### PR DESCRIPTION
### Brief Summary of Changes
Turn on CLDURLCache on by default
Turn off old ImageCache off by default

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
