### PR TITLE
Allow polymorphic return types on CLDRequestParams

### DIFF
--- a/Cloudinary/Classes/Core/Features/Helpers/RequestParams/CLDRequestParams.swift
+++ b/Cloudinary/Classes/Core/Features/Helpers/RequestParams/CLDRequestParams.swift
@@ -70,27 +70,27 @@ import Foundation
     
     */
     @discardableResult
-    open func setParam(_ key: String, value: Any?) -> CLDRequestParams {
+    open func setParam(_ key: String, value: Any?) -> Self {
         params[key] = value
         return self
     }
 
     @discardableResult
     @objc(setResourceTypeFromUrlResourceType:)
-    open func setResourceType(_ resourceType: CLDUrlResourceType) -> CLDRequestParams {
+    open func setResourceType(_ resourceType: CLDUrlResourceType) -> Self {
         return setResourceType(String(describing: resourceType))
     }
 
     @discardableResult
     @objc(setResourceTypeFromString:)
-    open func setResourceType(_ resourceType: String) -> CLDRequestParams {
+    open func setResourceType(_ resourceType: String) -> Self {
         self.resourceType = resourceType
         return self
     }
 
     @discardableResult
     @objc(setSignatureWithSignature:)
-    open func setSignature(_ signature: CLDSignature) -> CLDRequestParams {
+    open func setSignature(_ signature: CLDSignature) -> Self {
         self.signature = signature
         return self
     }


### PR DESCRIPTION
### Brief Summary of Changes
<!-- Provide some context as to what was changed, from an implementation standpoint. -->
Currently if you form a signature manually, setting the signature on an `CLDUploadRequestParams` returns a `CLDRequestParams` which requires the caller to cast the type back to `CLDUploadRequestParams`.

This change fixes it so `setSignature(_:)` correctly returns the subclass type. You'll notice this is already in place for `setApiKey(_:)`.

```swift
let parameters = CLDUploadRequestParams()
    .setSignature(
        .init(
            signature: decodedSignature.signature,
            timestamp: decodedSignature.timestamp as NSNumber
        )
    )
let uploadParameters = parameters as! CLDUploadRequestParams
```

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
