### PR TITLE
Feature/add privacy info file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.5.0 / 2024-01-29
+==================
+Other Changes
+-------------
+  * Support Privacy Manifest
+
 4.4.0 / 2024-01-15
 ==================
 Other Changes

--- a/Cloudinary.podspec
+++ b/Cloudinary.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'Cloudinary'
-    s.version          = '4.4.0'
+    s.version          = '4.5.0'
     s.summary          = "Cloudinary is a cloud service that offers a solution to a web application's entire image management pipeline."
     
     s.description      = <<-DESC

--- a/Cloudinary.podspec
+++ b/Cloudinary.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { "Cloudinary" => "info@cloudinary.com" }
     s.source           = { :git => "https://github.com/cloudinary/cloudinary_ios.git", :tag => s.version.to_s }
+    s.resource_bundles = {'Cloudinary' => ['Cloudinary/Classes/PrivacyInfo.xcprivacy']}
     
     s.swift_version         = '5.0'
     s.ios.deployment_target = '9.0'

--- a/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift
+++ b/Cloudinary/Classes/Core/Network/CLDNetworkCoordinator.swift
@@ -27,8 +27,8 @@ import UIKit
 
 internal class CLDNetworkCoordinator: NSObject {
 
-    static let DEFAULT_VERSION =        "4.4.0"
-    
+    static let DEFAULT_VERSION =        "4.5.0"
+
     fileprivate struct CLDNetworkCoordinatorConsts {
         static let BASE_CLOUDINARY_URL =    "https://api.cloudinary.com"
         static let API_KEY =                "api_key"

--- a/Cloudinary/Classes/PrivacyInfo.xcprivacy
+++ b/Cloudinary/Classes/PrivacyInfo.xcprivacy
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -21,6 +21,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Cloudinary",
-            path: "Cloudinary/Classes"),
+            path: "Cloudinary/Classes",
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
     ]
 )


### PR DESCRIPTION
### Brief Summary of Changes
I added `PrivacyInfo.xcprivacy`
<!-- Provide some context as to what was changed, from an implementation standpoint. -->

#### What does this PR address?
- [x] GitHub issue (Add reference - #418)

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

- Are all the data being collected listed?
- Are values related to data or API correct? 

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.

#### ScreenShots
I've checked that I could import Cloudinary including PrivacyInfo via CocoaPods or SwiftPM.

SwiftPM
<img width="370" alt="スクリーンショット 2024-01-29 14 13 40" src="https://github.com/cloudinary/cloudinary_ios/assets/44093643/a41a9d5d-dc56-4dec-999e-b69c3ab0caa9">

CocoaPods
<img width="882" alt="スクリーンショット 2024-01-29 14 19 53" src="https://github.com/cloudinary/cloudinary_ios/assets/44093643/dacc8873-a304-4caa-8977-05abc998f945">

PrivacyReports
<img width="1646" alt="スクリーンショット 2024-01-29 14 20 49" src="https://github.com/cloudinary/cloudinary_ios/assets/44093643/361161d3-91fc-4def-840c-7989f6ac272c">


