### PR TITLE
Bundle Privacy Manifest in SPM and CocoaPod distributions

### DIFF
--- a/Cloudinary.podspec
+++ b/Cloudinary.podspec
@@ -33,7 +33,8 @@ Pod::Spec.new do |s|
     s.subspec 'ios' do |spec|
         
         spec.platform              = :ios
-        spec.source_files          = 'Cloudinary/Classes/**/*'
-    
+        spec.source_files          = 'Cloudinary/Classes/**/*.{swift,h}'
+        spec.resource_bundles      = { 'Cloudinary' => ['Cloudinary/Classes/Core/Network/PrivacyInfo.xcprivacy'] }
+
     end
 end

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Cloudinary",
+    platforms: [ .iOS(.v9)],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Cloudinary",
+            targets: ["Cloudinary"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Cloudinary",
+            path: "Cloudinary/Classes",
+            resources: [
+                .copy("Core/Network/PrivacyInfo.xcprivacy")
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
### Brief Summary of Changes

Ensure that the PrivacyInfo.xcprivacy manifest is actually bundled as a resource in CocoaPod and SPM distributions so that it can be included in a host app and picked up by App Store Connect.

#### What does this PR address?
- [x] #418
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
We primarily use CocoaPods, and I assume that the expectation was that the privacy manifest would be picked up automatically because it was in the Cloudinary/Classes/ directory, but this is not the case:

<img width="1077" alt="Screenshot 2024-03-14 at 08 00 26" src="https://github.com/cloudinary/cloudinary_ios/assets/482871/d2b08e1a-6dfb-4916-8af6-d33267ab9a41">

The same goes for SPM (but no error is emitted) because it will only look for .swift sources in the target's path.

To solve this for CocoaPods, we have to make sure that `source_files` is only including .swift (and header?) files within Cloudinary/Classes and to solve this for Swift Package Manager, we have to add a copy resource rule for the manifest file.

Additionally for SPM, because Resource bundles were only added to Swift 5.3, I had to add a Package@swift-5.3.swift manifest because the main one sets the swift-tools-version to 5.1 still. 

We could also just bump the swift-tools-version to 5.3 (Xcode 12), but I wasn't sure if you support Swift 5.1 (Xcode 11) for enterprise clients who might still be using Xcode 11 for non-app store apps? 

After this change:

CocoaPods|Swift Package Manager
---|---
<img width="406" alt="CocoaPods" src="https://github.com/cloudinary/cloudinary_ios/assets/482871/1b8e446f-35ec-48bc-b98f-d053aacc696c">|<img width="586" alt="SPM" src="https://github.com/cloudinary/cloudinary_ios/assets/482871/c1a368ef-25ad-4616-b505-5a87a493c9f6">



#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
